### PR TITLE
Fix: wrong isChanged

### DIFF
--- a/src/MiFare.Shared/Classic/DataBlock.cs
+++ b/src/MiFare.Shared/Classic/DataBlock.cs
@@ -44,6 +44,6 @@ namespace MiFare.Classic
 
         public bool IsTrailer { get; }
 
-        public bool IsChanged => (!data.Equals(origData));
+        public bool IsChanged => (!data.SequenceEqual(origData));
     }
 }


### PR DESCRIPTION
Fix for issue #3 & #4 - wrong equality check for isChanged (credits to @qyen)
Every GetData() (or more accurate GetDataBlockInt()) read the datablock but on flush the isChanged flag was determined wrongly resulting in writing identical data. Without reading cards internals I guess this would extremly shorten the lifespan.