### PR TITLE
TestLogin & static key location map

### DIFF
--- a/src/MiFare/Classic/ICardReader.cs
+++ b/src/MiFare/Classic/ICardReader.cs
@@ -62,6 +62,17 @@ namespace MiFare.Classic
         Task<bool> Login(int sector, InternalKeyType key);
 
         /// <summary>
+        /// Tests if login into the given sector using the given key is possible
+        /// </summary>
+        /// <param name="sector">sector to login into</param>
+        /// <param name="keytype">keytype to use (e.g. KeyA, KeyB)</param>
+        /// <param name="key">key to use</param>
+        /// <returns>tru on success, false otherwise</returns>
+        Task<bool> TestLogin(int sector,KeyType keytype, byte[] key);
+
+
+
+        /// <summary>
         /// read a datablock from a sector 
         /// </summary>
         /// <param name="sector">sector to read</param>

--- a/src/MiFare/Classic/MiFARECard.cs
+++ b/src/MiFare/Classic/MiFARECard.cs
@@ -231,6 +231,20 @@ namespace MiFare.Classic
             }
         }
 
+
+
+        /// <summary>
+        /// Tests if login into the given sector using the given key is possible
+        /// </summary>
+        /// <param name="sector">sector to login into</param>
+        /// <param name="keytype">keytype to use (e.g. KeyA, KeyB)</param>
+        /// <param name="key">key to use</param>
+        /// <returns>tru on success, false otherwise</returns>
+        public async Task<bool> TestLogin(int sector, KeyType keytype, byte[] key)
+        {
+            return await GetSector(sector).TestLogin(keytype, key);
+        }
+
         /// <summary>
         ///     reinitialize the object
         /// </summary>

--- a/src/MiFare/Classic/MiFareStandardCardReaderBase.cs
+++ b/src/MiFare/Classic/MiFareStandardCardReaderBase.cs
@@ -22,7 +22,7 @@ namespace MiFare.Classic
        
         private Dictionary<SectorKey, byte[]> keyMap = new Dictionary<SectorKey, byte[]>();
 
-        private byte nextKeySlot;
+        private static byte nextKeySlot;
 
         private  static Dictionary<byte[], byte> keyToLocationMap = new Dictionary<byte[], byte>(KeyEqualityComparer.Default);
 

--- a/src/MiFare/Classic/Sector.cs
+++ b/src/MiFare/Classic/Sector.cs
@@ -205,6 +205,11 @@ namespace MiFare.Classic
                 throw new CardWriteException($"Unable to write in sector {sector}, block {dataBlock.Number}");
         }
 
+        public async Task<bool> TestLogin(KeyType keytype, byte[] key)
+        {
+            return await card.Reader.TestLogin(sector, keytype, key);
+        }
+
         private async Task<DataBlock> GetDataBlockInt(int block)
         {
             var db = dataBlocks[block];


### PR DESCRIPTION
Had some trouble when changing key (A or B doesn't matter) while keeping same instance/session. Even with calling abort() directly before this one didn't fix. I couldn't track down the error but stumbled over one case while searching for workaround:
MiFareCard inherits IDisposable which enables the following usage:
`using(MiFareCard mCard = smartcard.e.SmartCard.CreateMiFareCard()){ }`

Using this approach multiple times (for example as workaround for error named above) generated multiple keyLocationMaps for same underlying card reader. Without fully disposing the smartcard object the reader won't get in sync again. Just chaning it to static should do the trick.

While adding trace methodes I added TestLogin(...). As my project strongly depends on knowing which keytype-key combination was successful the integrated key failover (method Login(...) in MiFareStandardCardReaderBase) wasn't the right. The most of the method is plain copy&paste based on Login() just without key determination logic.

Hope this will be usefull for others as well.