### PR TITLE
Define conditional compilation symbols for working in desktop and UWP.

### DIFF
--- a/src/MiFare/Classic/AccessBits.cs
+++ b/src/MiFare/Classic/AccessBits.cs
@@ -11,7 +11,7 @@ namespace MiFare.Classic
     /// <summary>
     ///     Internal class for encoding/decoding the 4 control bytes in the trailer datablock of each sector
     /// </summary>
-    internal class AccessBits
+    public class AccessBits
     {
         /// <summary>
         ///     Calculate the 4 control bytes in the trailer datablock of each sector according to the given AccessConditions

--- a/src/MiFare/Classic/ICardReader.cs
+++ b/src/MiFare/Classic/ICardReader.cs
@@ -19,6 +19,7 @@ namespace MiFare.Classic
     {
         KeyA = GeneralAuthenticate.GeneralAuthenticateKeyType.MifareKeyA,
         KeyB = GeneralAuthenticate.GeneralAuthenticateKeyType.PicoTagPassKeyB,
+        KeyAOrB,
         KeyDefaultF
     }
 

--- a/src/MiFare/Classic/MAD.cs
+++ b/src/MiFare/Classic/MAD.cs
@@ -99,7 +99,7 @@ namespace MiFare.Classic
 
             Byte crc = CalculateCRC();
             if (_Block1[0] != crc)
-                crc = _Block1[0];
+                _Block1[0] = crc;
         }
         #endregion
 

--- a/src/MiFare/Classic/MiFARECard.cs
+++ b/src/MiFare/Classic/MiFARECard.cs
@@ -256,7 +256,7 @@ namespace MiFare.Classic
             Initialize();
         }
 
-        private async Task InitMad()
+        public async Task InitMad()
         {
             if (mad != null)
                 return;

--- a/src/MiFare/Classic/Sector.cs
+++ b/src/MiFare/Classic/Sector.cs
@@ -41,6 +41,18 @@ namespace MiFare.Classic
 
                 return access;
             }
+            set
+            {
+                access = value;
+                if (originalAccessConditions == null)
+                {
+                    var data = GetData(TrailerBlockIndex)
+                        .Result;
+                    // Store a copy for determining write key for later
+                    originalAccessConditions = AccessBits.GetAccessConditions(data);
+
+                }
+            }
         }
 
         /// <summary>
@@ -195,9 +207,7 @@ namespace MiFare.Classic
             if (card.ActiveSector != sector)
             {
                 var writeKey = GetWriteKey(dataBlock.Number);
-                if (!await card.Reader.Login(sector, writeKey))
-                    throw new CardLoginException($"Unable to login in sector {sector} with key {writeKey}");
-
+                await TryLogin(writeKey);
                 card.ActiveSector = sector;
             }
 
@@ -242,7 +252,19 @@ namespace MiFare.Classic
             if (Access == null)
                 return InternalKeyType.KeyDefaultF;
 
-            return (originalAccessConditions.Trailer.AccessBitsWrite == TrailerAccessCondition.ConditionEnum.KeyA) ? InternalKeyType.KeyA : InternalKeyType.KeyB;
+            switch (originalAccessConditions.Trailer.AccessBitsWrite)
+            {
+                case TrailerAccessCondition.ConditionEnum.Never:
+                    throw new CardWriteException($"Write in trailer block of sector {sector} is not allowed");
+                case TrailerAccessCondition.ConditionEnum.KeyA:
+                    return InternalKeyType.KeyA;
+                case TrailerAccessCondition.ConditionEnum.KeyB:
+                    return InternalKeyType.KeyB;
+                case TrailerAccessCondition.ConditionEnum.KeyAOrB:
+                    return InternalKeyType.KeyAOrB;
+                default:
+                    return InternalKeyType.KeyDefaultF;
+            }
         }
 
         private InternalKeyType GetWriteKey(int datablock)
@@ -253,7 +275,36 @@ namespace MiFare.Classic
             if (datablock == TrailerBlockIndex)
                 return GetTrailerWriteKey();
 
-            return (originalAccessConditions.DataAreas[Math.Min(datablock, Access.DataAreas.Length - 1)].Write == DataAreaAccessCondition.ConditionEnum.KeyA) ? InternalKeyType.KeyA : InternalKeyType.KeyB;
+            switch (originalAccessConditions.DataAreas[Math.Min(datablock, Access.DataAreas.Length - 1)].Write)
+            {
+                case DataAreaAccessCondition.ConditionEnum.Never:
+                    throw new CardWriteException($"Write in sector {sector}, block {datablock} is not allowed");
+                case DataAreaAccessCondition.ConditionEnum.KeyA:
+                    return InternalKeyType.KeyA;
+                case DataAreaAccessCondition.ConditionEnum.KeyB:
+                    return InternalKeyType.KeyB;
+                case DataAreaAccessCondition.ConditionEnum.KeyAOrB:
+                    return InternalKeyType.KeyAOrB;
+                default:
+                    return InternalKeyType.KeyDefaultF;
+            }
+        }
+
+        private async Task TryLogin(InternalKeyType writeKey)
+        {
+            if (writeKey == InternalKeyType.KeyAOrB)
+            {
+                if (!await card.Reader.Login(sector, InternalKeyType.KeyA) &&
+                    !await card.Reader.Login(sector, InternalKeyType.KeyB))
+                {
+                    throw new CardLoginException($"Unable to login in sector {sector} with key A or B");
+                }
+            }
+            else
+            {
+                if (!await card.Reader.Login(sector, writeKey))
+                    throw new CardLoginException($"Unable to login in sector {sector} with key {writeKey}");
+            }
         }
     }
 }

--- a/src/MiFare/Classic/Sector.cs
+++ b/src/MiFare/Classic/Sector.cs
@@ -303,7 +303,7 @@ namespace MiFare.Classic
             else
             {
                 if (!await card.Reader.Login(sector, writeKey))
-                    throw new CardLoginException($"Unable to login in sector {sector} with key {writeKey}");
+                    throw new CardLoginException($"Unable to login in sector {sector} with the key {writeKey} required to write");
             }
         }
     }

--- a/src/MiFare/MiFare.csproj
+++ b/src/MiFare/MiFare.csproj
@@ -24,6 +24,13 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>WINDOWS_APP</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
+    <DefineConstants>WINDOWS_UAP</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />

--- a/src/MiFare/Platforms/net/CardReader.cs
+++ b/src/MiFare/Platforms/net/CardReader.cs
@@ -25,7 +25,7 @@ namespace MiFare
                 var names = GetReaderNames();
                 if (names.Count == 0)
                 {
-                    return null;
+                    return Task.FromResult<SmartCardReader>(null);
                 }
                 if (names.Count > 1)
                 {


### PR DESCRIPTION
WINDOWS_APP constant was not being defined and the login was failing in desktop applications. Now the conditional code in MiFare.PcSc.MiFareStandard.LoadKey.GetLoadKeysType() is working properly.